### PR TITLE
# [#38-2] [FE] 게시글 수정페이지

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -87,6 +87,7 @@ const App = () => {
           <Route path="/board" element={<Board />} />
           <Route path="/board/:nickname" element={<MyPostingList />} />
           <Route path="/board/posting/:id" element={<PostingDetail />} />
+          <Route path="/board/write/:id" element={<PostingEditor />} />
         </Routes>
         <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
       </QueryClientProvider>

--- a/src/components/board/PostingDetail.js
+++ b/src/components/board/PostingDetail.js
@@ -8,7 +8,7 @@ import styled, { ThemeProvider } from "styled-components";
 
 import theme from "../../styles/theme";
 import Modal from "../common/Modal";
-import { ERROR_MESSAGE, LOADING_MESSAGE } from "../../constants";
+import { LOADING_MESSAGE } from "../../constants";
 import Message from "../common/Message";
 import ResponseMessage from "../common/ResponseMessage";
 import { StyledButton } from "../common/CommonStyle";
@@ -33,8 +33,8 @@ const PostingDetail = () => {
   const title = data?.posting?.title;
   const content = data?.posting?.content;
 
-  const handleEditPosting = () => {
-    navigate(`/board/write/${id}`);
+  const handleEditPosting = (id, posting) => {
+    navigate(`/board/write/${id}`, { state: posting });
   };
 
   const handleDeletePosting = async () => {
@@ -61,7 +61,10 @@ const PostingDetail = () => {
         <Editor>
           <div dangerouslySetInnerHTML={{ __html: content }} />
         </Editor>
-        <Button type="submit" onClick={handleEditPosting}>
+        <Button
+          type="submit"
+          onClick={() => handleEditPosting(id, data.posting)}
+        >
           Edit
         </Button>
         <Button type="submit" onClick={handleDeletePosting}>
@@ -75,7 +78,7 @@ const PostingDetail = () => {
 export default PostingDetail;
 
 const Container = styled.div`
-  maxwidth: 700px;
+  max-width: 700px;
   margin: auto 50px;
 `;
 
@@ -90,14 +93,4 @@ const Editor = styled.div`
   height: 400px;
   margin: 10px auto;
   border: 1px solid black;
-`;
-
-const WarningMessage = styled.div`
-  width: 100%;
-  height: 10%;
-  margin-bottom: ${({ theme }) => theme.spacing.base};
-  color: red;
-  font-size: ${({ theme }) => theme.fontSizes.small};
-  font-weight: 700;
-  text-align: center;
 `;

--- a/src/components/posting/PostingEditor.js
+++ b/src/components/posting/PostingEditor.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
 import axios from "axios";
@@ -9,6 +9,7 @@ import styled, { ThemeProvider } from "styled-components";
 import { postingPhotoActions } from "../../features/postingPhotoSlice";
 import theme from "../../styles/theme";
 import { StyledButton } from "../common/CommonStyle";
+import ResponseMessage from "../common/ResponseMessage";
 
 const regionList = [
   "서울특별시",
@@ -35,6 +36,8 @@ const regionList = [
 const PostingEditor = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const location = useLocation();
+  const { id: postingId } = useParams();
 
   const quillRef = useRef();
   const { user } = useSelector(state => state.user);
@@ -45,6 +48,7 @@ const PostingEditor = () => {
   const [hashtags, setHashtags] = useState("");
   const [regions, setRegions] = useState([]);
   const [logOption, setLogOption] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const imageUrl = photoUrl[Math.floor(Math.random() * photoUrl.length)];
 
   const [warnMsgs, setWarnMsgs] = useState({
@@ -57,7 +61,7 @@ const PostingEditor = () => {
   });
 
   const imageHandler = () => {
-    navigate(user.id);
+    navigate(`/board/new-posting/${user.id}`);
   };
 
   const modules = useMemo(() => {
@@ -84,11 +88,31 @@ const PostingEditor = () => {
     };
   }, []);
 
+  if (!isEditing && location.pathname.includes("write")) {
+    setIsEditing(true);
+  }
+
   useEffect(() => {
-    if (photoUrl[photoUrl.length - 1]) {
-      setContent(
-        content.concat("<img src=", photoUrl[photoUrl.length - 1], " /><br />")
-      );
+    if (location.state) {
+      const { title, content, hashtags, regions, logOption } = location.state;
+
+      setTitle(title);
+      setContent(content);
+      setHashtags(hashtags.toString());
+      setRegions(regions);
+      setLogOption(logOption);
+
+      location.state = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const latestPhotoUrl = photoUrl[photoUrl.length - 1];
+
+    if (latestPhotoUrl) {
+      setContent(prev => {
+        return prev.concat(`<img src="${latestPhotoUrl}" /><br />`);
+      });
     }
   }, [photoUrl.length]);
 
@@ -100,9 +124,10 @@ const PostingEditor = () => {
     }
   };
 
-  const handleSubmit = event => {
+  const handleSubmit = async event => {
     event.preventDefault();
 
+    const latestPhotoUrl = photoUrl[photoUrl.length - 1];
     const splitedHashtags = hashtags.split(",").map(hash => hash.trim());
 
     if (
@@ -126,7 +151,31 @@ const PostingEditor = () => {
       return;
     }
 
-    axios.post("/posting/new", {
+    if (isEditing) {
+      const { data } = await axios.put(`/posting/${postingId}`, {
+        posting: {
+          title,
+          content,
+          hashtags: splitedHashtags,
+          regions,
+          logOption,
+          imageUrl: latestPhotoUrl,
+        },
+      });
+
+      if (data.error) {
+        return <ResponseMessage message={data.error.message} />;
+      }
+
+      if (data.result === "ok") {
+        navigate(`/board/posting/${postingId}`);
+        dispatch(postingPhotoActions.resetPhotoUrl());
+      }
+
+      return;
+    }
+
+    const { data } = await axios.post("/posting/new", {
       posting: {
         title,
         createdBy: user.nickname,
@@ -139,46 +188,61 @@ const PostingEditor = () => {
       user: user.id,
     });
 
-    setWarnMsgs({ ...warnMsgs, result: "posting이 생성되었습니다" });
-    dispatch(postingPhotoActions.resetPhotoUrl());
+    if (data.error) {
+      return <ResponseMessage message={data.error.message} />;
+    }
+
+    if (data.result === "ok") {
+      setWarnMsgs({ ...warnMsgs, result: "posting이 생성되었습니다" });
+      dispatch(postingPhotoActions.resetPhotoUrl());
+    }
   };
 
   return (
     <ThemeProvider theme={theme}>
       <Container>
-        <Title style={{ maxWidth: "700px", margin: "2rem auto" }}>
+        <Title
+          style={{ maxWidth: "700px", margin: "2rem auto", fontSize: "25px" }}
+        >
           <div style={{ textAlign: "center" }}>
-            <span>NEW POSTING BOARD</span>
+            <span>
+              {isEditing ? "📃 EDIT YOUR POSTING" : "📃 NEW POSTING BOARD"}
+            </span>
           </div>
         </Title>
 
-        <form onSubmit={handleSubmit}>
+        <Form onSubmit={handleSubmit}>
           <Editor>
-            Title :
-            <input name="title" onChange={e => setTitle(e.target.value)} />
+            <TitleInput
+              name="title"
+              placeholder="Title"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+            />
             <WarningMessage>{warnMsgs.title || ""}</WarningMessage>
             <ReactQuill
               ref={quillRef}
               theme="snow"
-              placeholder="Type here"
+              placeholder="Type your photolog"
               value={content}
               onChange={e => setContent(e)}
               modules={modules}
             />
             <WarningMessage>{warnMsgs.content || ""}</WarningMessage>
-            Hashtags :
             <div>
-              <input
+              <HashTagInput
                 name="hashtags"
+                value={hashtags}
+                placeholder="Hash tags"
                 onChange={e => setHashtags(e.target.value)}
               />
             </div>
             <WarningMessage>{warnMsgs.hashtag || ""}</WarningMessage>
-            <p>Region</p>
-            <div>
-              {regionList?.map(item => (
+            <p>[Region]</p>
+            <RegionCheck>
+              {regionList.map(item => (
                 <div key={item.key}>
-                  <input
+                  <RegionItem
                     type="checkbox"
                     name="region"
                     value={item}
@@ -190,27 +254,28 @@ const PostingEditor = () => {
                   {item}
                 </div>
               ))}
-            </div>
+            </RegionCheck>
             <WarningMessage>{warnMsgs.regions || ""}</WarningMessage>
-            <h3>[Log option] 날짜별 방문기록 장소를 보여주시겠습니까 ? </h3>
-            <select
+            <LogOptionTitle>
+              [Log option] 날짜별 방문기록 장소를 보여주시겠습니까 ?
+            </LogOptionTitle>
+            <LogOptionItem
               name="logOption"
+              value={logOption}
               onChange={e => setLogOption(e.target.value)}
             >
               <option value="옵션선택">옵션선택</option>
               <option value="true">예</option>
               <option value="false">아니요</option>
-            </select>
+            </LogOptionItem>
             <WarningMessage>{warnMsgs.logOption || ""}</WarningMessage>
             <div style={{ textAlign: "center", margin: "2rem" }}>
-              <WarningMessage>{warnMsgs.result}</WarningMessage>
-              <Button type="submit" onClick={() => navigate("/board")}>
-                BACK
-              </Button>
-              <Button type="submit">SAVE</Button>
+              <WarningMessage>{warnMsgs.result || ""}</WarningMessage>
+              <Button type="submit">{isEditing ? "UPDATE" : "SAVE"}</Button>
+              <Button onClick={() => navigate("/board")}>BACK</Button>
             </div>
           </Editor>
-        </form>
+        </Form>
       </Container>
     </ThemeProvider>
   );
@@ -219,26 +284,80 @@ const PostingEditor = () => {
 export default PostingEditor;
 
 const Container = styled.div`
-  maxwidth: 700px;
-  margin: auto 50px;
+  width: 80%;
+  margin: 10px auto;
+`;
+
+const Form = styled.form`
+  margin: 10px auto;
+`;
+
+const TitleInput = styled.input`
+  width: 100%;
+  border: none;
+  border-bottom: 1px solid gray;
+  font-size: 20px;
+  &:hover : {
+    background-color: #f8fff8;
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+
+const HashTagInput = styled.input`
+  width: 100%;
+  border: none;
+  border-bottom: 1px dotted gray;
+  font-size: 15px;
+  &:hover : {
+    background-color: #f8fff8;
+  }
+  &:focus {
+    outline: none;
+  }
+`;
+
+const RegionCheck = styled.div`
+  display: inline-flex;
+  flex-wrap: wrap;
+  width: 100%;
+  text-overflow: ellipsis;
+  white-space: normal;
+`;
+
+const RegionItem = styled.input`
+  margin: 5px;
+`;
+
+const LogOptionTitle = styled.h3`
+  display: inline-block;
+`;
+
+const LogOptionItem = styled.select`
+  border: none;
+  border-bottom: 1px solid gray;
 `;
 
 const Title = styled.div``;
 
 const Button = styled(StyledButton)`
-  padding: 10px;
+  display: inline;
+  padding: 5px;
+  border-radius: 5px;
+  background-color: #dcedc8;
 `;
 
 const Editor = styled.div`
   width: 80%;
-  margin: 10px;
+  margin: 10px auto;
 `;
 
 const WarningMessage = styled.div`
   width: 100%;
   height: 10%;
   margin-bottom: ${({ theme }) => theme.spacing.base};
-  color: red;
+  color: #a5b592;
   font-size: ${({ theme }) => theme.fontSizes.small};
   font-weight: 700;
   text-align: center;

--- a/src/components/posting/PostingEditor.js
+++ b/src/components/posting/PostingEditor.js
@@ -217,27 +217,27 @@ const PostingEditor = () => {
               name="title"
               placeholder="Title"
               value={title}
-              onChange={e => setTitle(e.target.value)}
+              onChange={event => setTitle(event.target.value)}
             />
-            <WarningMessage>{warnMsgs.title || ""}</WarningMessage>
+            <WarningMessage>{warnMsgs.title || <div />}</WarningMessage>
             <ReactQuill
               ref={quillRef}
               theme="snow"
               placeholder="Type your photolog"
               value={content}
-              onChange={e => setContent(e)}
+              onChange={event => setContent(event)}
               modules={modules}
             />
-            <WarningMessage>{warnMsgs.content || ""}</WarningMessage>
+            <WarningMessage>{warnMsgs.content || <div />}</WarningMessage>
             <div>
               <HashTagInput
                 name="hashtags"
                 value={hashtags}
                 placeholder="Hash tags"
-                onChange={e => setHashtags(e.target.value)}
+                onChange={event => setHashtags(event.target.value)}
               />
             </div>
-            <WarningMessage>{warnMsgs.hashtag || ""}</WarningMessage>
+            <WarningMessage>{warnMsgs.hashtag || <div />}</WarningMessage>
             <p>[Region]</p>
             <RegionCheck>
               {regionList.map(item => (
@@ -246,8 +246,8 @@ const PostingEditor = () => {
                     type="checkbox"
                     name="region"
                     value={item}
-                    onChange={e => {
-                      handleChangeRegions(e.currentTarget.checked, item);
+                    onChange={event => {
+                      handleChangeRegions(event.currentTarget.checked, item);
                     }}
                     checked={!!regions.includes(item)}
                   />
@@ -255,22 +255,22 @@ const PostingEditor = () => {
                 </div>
               ))}
             </RegionCheck>
-            <WarningMessage>{warnMsgs.regions || ""}</WarningMessage>
+            <WarningMessage>{warnMsgs.regions || <div />}</WarningMessage>
             <LogOptionTitle>
               [Log option] 날짜별 방문기록 장소를 보여주시겠습니까 ?
             </LogOptionTitle>
             <LogOptionItem
               name="logOption"
               value={logOption}
-              onChange={e => setLogOption(e.target.value)}
+              onChange={event => setLogOption(event.target.value)}
             >
               <option value="옵션선택">옵션선택</option>
               <option value="true">예</option>
               <option value="false">아니요</option>
             </LogOptionItem>
-            <WarningMessage>{warnMsgs.logOption || ""}</WarningMessage>
+            <WarningMessage>{warnMsgs.logOption || <div />}</WarningMessage>
             <div style={{ textAlign: "center", margin: "2rem" }}>
-              <WarningMessage>{warnMsgs.result || ""}</WarningMessage>
+              <WarningMessage>{warnMsgs.result || <div />}</WarningMessage>
               <Button type="submit">{isEditing ? "UPDATE" : "SAVE"}</Button>
               <Button onClick={() => navigate("/board")}>BACK</Button>
             </div>


### PR DESCRIPTION
# [#38-2] [FE] 게시글 수정페이지

## 노션 칸반 링크

- [[FE] 게시글 수정페이지
  ](https://www.notion.so/vanillacoding/FE-ed0890cc7cfe4abfa6531022804717e2)

## 카드에서 구현 혹은 해결하려는 내용

- 게시글 에디터 수정 기능 추가 (기존 Editor 컴포넌트 재사용)
  - 게시글 디테일 페이지에서 EDIT 버튼 클릭시 해당 게시글 내용을 Editor 컴포넌트 상에 랜더링
  - 내용 수정 후 UPDATE 버튼 클릭 시 해당 게시글 데이터베이스 내용 수정 요청 전송 후 게시글 디테일 페이지로 리랜더링

## 테스트 방법

- 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- 에디터 내 사용자 인풋에 대한 검증작업은 서영님께서 작업해주시기로 말씀해주셔서 따로 수정하지 않았습니다.
- 게시글 디테일 페이지에서 게시글을 작성한 유저가 아니라면 EDIT, DELETE 버튼이 보이지 않도록 조건부 랜더링이 필요합니다. 게시글 디테일 페이지 작업해주실때 확인 부탁드립니다:)
