### PR TITLE
[#23-1] [FE] 댓글 불러오기 수정

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -6,6 +6,7 @@ import userReducer from "../features/userSlice";
 import photoReducer from "../features/photoSlice";
 import postingPhotoReducer from "../features/postingPhotoSlice";
 import searchingReducer from "../features/searchingSlice";
+import urlReducer from "../features/urlSlice";
 
 const store = configureStore({
   reducer: {
@@ -14,6 +15,7 @@ const store = configureStore({
     photo: photoReducer,
     postingPhoto: postingPhotoReducer,
     searching: searchingReducer,
+    url: urlReducer,
   },
   middleware: getDefaultMiddleware => getDefaultMiddleware().concat(logger),
 });

--- a/src/components/photo/Comment.js
+++ b/src/components/photo/Comment.js
@@ -6,13 +6,8 @@ import dayjs from "dayjs";
 import axios from "axios";
 import styled, { ThemeProvider } from "styled-components";
 
-import {
-  ERROR_MESSAGE,
-  LOADING_MESSAGE,
-  RESPONSE_MESSAGE,
-} from "../../constants";
+import { ERROR_MESSAGE, RESPONSE_MESSAGE } from "../../constants";
 import theme from "../../styles/theme";
-import Message from "../common/Message";
 
 const Comment = ({ comment, onSet }) => {
   const [hasError, setHasError] = useState(false);

--- a/src/components/photo/Comment.js
+++ b/src/components/photo/Comment.js
@@ -14,7 +14,7 @@ import {
 import theme from "../../styles/theme";
 import Message from "../common/Message";
 
-const Comment = ({ comment }) => {
+const Comment = ({ comment, onSet }) => {
   const [hasError, setHasError] = useState(false);
   const [isDelete, setIsDelete] = useState(false);
   const index = useSelector(state => state.photo.currentIndex);
@@ -43,11 +43,13 @@ const Comment = ({ comment }) => {
   );
 
   if (isLoading || isFetching) {
-    return <Message message={LOADING_MESSAGE.SENDING_IN_PROGRESS} />;
+    return <div />;
   }
 
   if (data?.comments) {
-    // 소켓..?
+    onSet(data.comments);
+
+    queryClient.resetQueries("deleteComment");
   }
 
   if (data?.error) {

--- a/src/components/photo/PhotoList.js
+++ b/src/components/photo/PhotoList.js
@@ -13,12 +13,13 @@ import { photoActions } from "../../features/photoSlice";
 import Message from "../common/Message";
 import Modal from "../common/Modal";
 import Photo from "./Photo";
+import { urlAction } from "../../features/urlSlice";
 
 const PhotoList = () => {
   const { id: mapId } = useParams();
   const { search: query } = useLocation();
-  const navigate = useNavigate();
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const handlePhotoClick = event => {
     const photoId = event.currentTarget.id;
@@ -34,8 +35,10 @@ const PhotoList = () => {
 
   const getPhotos = (query, mapId) => {
     const queryForMapList = `${query}&map=${mapId}`;
+    const url = `/point/photos${decodeURI(queryForMapList)}`;
+    dispatch(urlAction.setUrl({ url }));
 
-    return axios.get(`/point/photos${decodeURI(queryForMapList)}`);
+    return axios.get(url);
   };
 
   const { data, isLoading, isFetching, isError, error } = useQuery(

--- a/src/features/urlSlice.js
+++ b/src/features/urlSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  url: "",
+};
+
+const urlSlice = createSlice({
+  name: "url",
+  initialState,
+  reducers: {
+    setUrl: (state, action) => {
+      state.url = action.payload.url;
+
+      return state;
+    },
+  },
+});
+
+export const urlAction = urlSlice.actions;
+export default urlSlice.reducer;


### PR DESCRIPTION
# [#23-1] {[FE] 댓글 불러오기 수정}

## 노션 칸반 링크

- [[FE] 댓글 불러오기 수정](https://www.notion.so/vanillacoding/FE-5a0ba47f7d8744b09b0f8e111bc90f08)
  ​

## 카드에서 구현 혹은 해결하려는 내용

- 사진에 대한 댓글을 보여줄 때  캐시된 데이터를 사용했었는데, 댓글 등록 / 삭제 시 바로바로 반영이 되지 않는 한계가 있었습니다. 그래서 댓글 컴포넌트에서 직접 서버에 요청을 보내, 받아온 댓글을 뿌려주는 형식으로 수정하였습니다.